### PR TITLE
Better center text alignment for box & line titles

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gg/app",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "type": "module",
   "license": "See ../LICENSE.md",
   "types": "./dist/index.d.ts",

--- a/app/src/operations/select.ts
+++ b/app/src/operations/select.ts
@@ -682,7 +682,6 @@ function onTextFontChange(state: State, value: TextFont): void {
     modifySpecification(() => {
       for (const subsystem of multiSelectVisual.selected) {
         const size = calculateTextSizeForSubsystem(
-          subsystem,
           subsystem.title.replaceAll("\\n", "\n"),
           value,
           subsystem.titleAlign,
@@ -708,7 +707,6 @@ function onTextFontChange(state: State, value: TextFont): void {
   if (oneSystemSelected) {
     modifySpecification(() => {
       const size = calculateTextSizeForSubsystem(
-        oneSystemSelected!,
         oneSystemSelected!.title.replaceAll("\\n", "\n"),
         value,
         oneSystemSelected!.titleAlign,

--- a/app/src/operations/setTitle.ts
+++ b/app/src/operations/setTitle.ts
@@ -158,7 +158,6 @@ document
       modifySpecification(() => {
         if (subsystem) {
           const size = calculateTextSizeForSubsystem(
-            subsystem,
             editor.value,
             getFont(),
             getAlign(),

--- a/core/src/simulator.ts
+++ b/core/src/simulator.ts
@@ -154,6 +154,11 @@ interface GridSystem {
   type: SubsystemType | "linkTitle";
 
   title: {
+    // The simulator align text on a grid, for routing & collisions purposes.
+    // This alignment is not pixel-perfect like the renderer is capable to do.
+    // Therefore, the following property is introduced for the renderer to
+    // perform its own text alignement.
+    renderX: number;
     x: number;
     y: number;
     width: number;
@@ -459,6 +464,7 @@ export class SystemSimulator {
       height: -1,
       margin: structuredClone(system.margin),
       title: {
+        renderX: -1,
         x: -1,
         y: -1,
         width: -1,
@@ -533,8 +539,21 @@ export class SystemSimulator {
 
     const gridSystem = this.gridSystems[system.id]!;
 
+    let x: number;
+
+    if (system.titleAlign === "center") {
+      x = Math.floor(
+        gridSystem.x1 + gridSystem.width / 2 - system.titleSize.width / 2,
+      );
+    } else if (system.titleAlign === "right") {
+      x = gridSystem.x2 - system.titleSize.width;
+    } else {
+      x = gridSystem.x1 + system.padding.left + system.titleMargin.left;
+    }
+
     gridSystem.title = {
-      x: gridSystem.x1 + system.padding.left + system.titleMargin.left,
+      renderX: gridSystem.x1 + system.padding.left + system.titleMargin.left,
+      x,
       y: gridSystem.y1 + system.padding.top + system.titleMargin.top,
       width: system.titleSize.width,
       height: system.titleSize.height,
@@ -955,7 +974,7 @@ export class SystemSimulator {
         zIndex: SimulatorObjectZIndex.SystemTitle + ss.depth,
       };
 
-      this.grid[gridSS.title.x]![gridSS.title.y]!.push(
+      this.grid[gridSS.title.renderX]![gridSS.title.y]!.push(
         simulatorSystemTitleText,
       );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "app": {
       "name": "@gg/app",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "license": "See ../LICENSE.md",
       "dependencies": {
         "@gg/core": "0.x",


### PR DESCRIPTION
- Fixes #60 by modifying the way text is centered both in the simulation & renderer. The bottom line is that `titleSize` is not updated when the text is aligned, which was causing issues in conjunction with resizing a box.
- Fixes #52