### PR TITLE
Set title of box with double click after cloning it

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gg/app",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "type": "module",
   "license": "See ../LICENSE.md",
   "types": "./dist/index.d.ts",

--- a/app/src/operations/select.ts
+++ b/app/src/operations/select.ts
@@ -1453,7 +1453,14 @@ function onPointerUp(state: State): void {
               systemToDuplicate.links,
             );
 
-            multiSelectVisual.setSelectedFromSubsystems(newSystems);
+            if (newSystems.length > 1) {
+              // Multiple sub-systems were duplicated. Select them.
+              multiSelectVisual.setSelectedFromSubsystems(newSystems);
+            } else {
+              // A single sub-system was duplicated. Select it.
+              onBegin(state);
+              oneSystemSelected = newSystems[0];
+            }
           } else {
             moveSystems(multiSelectVisual.selected, deltaX, deltaY);
           }
@@ -1621,7 +1628,7 @@ function onPointerUp(state: State): void {
   }
 
   //
-  // Move or duplicate one system into a container, or not.
+  // Move one system into a container, or not.
   //
   if (oneSystemSelected && oneSystemPickedUpAt) {
     let parent =

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "app": {
       "name": "@gg/app",
-      "version": "0.9.15",
+      "version": "0.9.16",
       "license": "See ../LICENSE.md",
       "dependencies": {
         "@gg/core": "0.x",


### PR DESCRIPTION
Fixes #91 

Duplicating one or many boxes uses the same code path so when the duplication is done, we must distinguish between selecting one box vs selecting multiple boxes.