### PR TITLE
Fix triggering an operation twice

### DIFF
--- a/app/src/operations/erase.ts
+++ b/app/src/operations/erase.ts
@@ -156,6 +156,7 @@ function onBegin(state: State): void {
   // Shared.
   //
   viewport.pause = false;
+  inCanvas = true;
   onPointerMove(state);
 }
 
@@ -238,6 +239,7 @@ const operation: Operation = {
     selectLinkVisual2.visible = false;
 
     viewport.pause = false;
+    inCanvas = true;
   },
   onPointerDown: state => {
     viewport.pause = true;

--- a/app/src/operations/link.ts
+++ b/app/src/operations/link.ts
@@ -365,6 +365,7 @@ function onBegin(state: State): void {
   setNewLineProperties();
 
   viewport.pause = false;
+  inCanvas = true;
   onPointerMove(state);
 }
 
@@ -810,6 +811,7 @@ const operation: Operation = {
   onEnd: () => {
     resetSingleSelection();
     viewport.pause = false;
+    inCanvas = true;
   },
   onPointerDown: state => {
     viewport.pause = true;

--- a/app/src/operations/select.ts
+++ b/app/src/operations/select.ts
@@ -561,6 +561,7 @@ function onBegin(state: State): void {
   systemToDuplicate = null;
 
   viewport.pause = false;
+  inCanvas = true;
   onPointerMove(state);
 }
 
@@ -1745,6 +1746,7 @@ const operation: Operation = {
     // Shared.
     //
     viewport.pause = false;
+    inCanvas = true;
   },
   onPointerDown: state => {
     viewport.pause = true;


### PR DESCRIPTION
This bug occurs because `onPointerDown` and `onWindowPointerDown` are both triggered and the `inCanvas` state has the wrong value.